### PR TITLE
Two improvements and a bug fix

### DIFF
--- a/bdf.go
+++ b/bdf.go
@@ -294,7 +294,7 @@ func (f *Face) Glyph(dot fixed.Point26_6, r rune) (dr image.Rectangle, mask imag
 
 	mask = c.Alpha
 
-	x := int(dot.X)>>6 - c.LowerPoint[0]
+	x := int(dot.X)>>6 + c.LowerPoint[0]
 	y := int(dot.Y)>>6 - c.LowerPoint[1]
 	dr = image.Rectangle{
 		Min: image.Point{
@@ -316,7 +316,7 @@ func (f *Face) GlyphBounds(r rune) (bounds fixed.Rectangle26_6, advance fixed.In
 		return fixed.R(0, -f.Font.Ascent, 0, +f.Font.Descent), 0, false
 	}
 
-	return fixed.R(0, -f.Font.Ascent, c.Alpha.Rect.Max.X, +f.Font.Descent), fixed.I(c.Advance[0]), true
+	return fixed.R(c.LowerPoint[0], -f.Font.Ascent, c.LowerPoint[0]+c.Alpha.Rect.Dx(), f.Font.Descent), fixed.I(c.Advance[0]), true
 }
 
 func (f *Face) GlyphAdvance(r rune) (advance fixed.Int26_6, ok bool) {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/zachomedia/go-bdf
+
+go 1.16
+
+require (
+	golang.org/x/image v0.0.0-20210504121937-7319ad40d33e
+	golang.org/x/text v0.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/image v0.0.0-20210504121937-7319ad40d33e h1:PzJMNfFQx+QO9hrC1GwZ4BoPGeNGhfeQEgcQFArEjPk=
+golang.org/x/image v0.0.0-20210504121937-7319ad40d33e/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This PR adds

* basic support for encodings, for a limited set of common encodings that I found in BDF files
* support for the DEFAULT_CHAR to get better fallback character handling

and fixes the use of the bounding box offset in `Glyph` and `GlyphBounds`.
